### PR TITLE
setting filename from log improvement.

### DIFF
--- a/script.py
+++ b/script.py
@@ -34,7 +34,7 @@ elif sys.platform == 'darwin':
 elif sys.platform.startswith('linux'):
     filename = '/var/lib/plexmediaserver/Library/Application Support/Plex Media Server/Logs/Plex Media Server.log'
 else:
-    print 'OS not detected correctly'
+    print 'OS not detected correctly, please specify log path in config.ini'
 
 url = 'http://localhost:32400/'
 api_key = 'aebda823a279b219476c565be863d83739999502'


### PR DESCRIPTION
setting filename from log improvement. No need to set filename twice, also for undetected OS but having log file in config.ini you wont get "OS detection failed" but then the script continue to work (as path from log is set AFTER the error message).

It will now check config.ini first and if not specified AND OS detection failed - it will tell you to add it.
