### PR TITLE
Support for DLNA clients

### DIFF
--- a/Trakttv.bundle/Contents/Code/__init__.py
+++ b/Trakttv.bundle/Contents/Code/__init__.py
@@ -601,9 +601,10 @@ def Scrobble():
         try:
             log_values = dict(LOG_REGEXP.findall(line))
             #Log(log_values)
-            if log_values['key'] != None:
+            key = log_values.get('key', log_values.get('ratingKey', None))
+            if key is not None:
                 #Log('Playing something')
-                watch_or_scrobble(log_values['key'], log_values['time'])
+                watch_or_scrobble(key, log_values['time'])
         except:
             pass
 


### PR DESCRIPTION
Credit goes to `coolweb` from the plex forums. This should close out #30.

The only issue I noticed in testing this is that the DLNA client will sometimes report being farther into the media than it actually is, then trigger a scrobble too soon (rather than at actual 80%).
