### PR TITLE
Detect resolution metadata using the video width instead of height

### DIFF
--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/handlers/collection/push.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/handlers/collection/push.py
@@ -60,24 +60,24 @@ class Base(PushHandler, CollectionHandler):
         return None
 
     @staticmethod
-    def get_resolution(height, interlaced):
+    def get_resolution(width, interlaced):
         # 4k
-        if height > 1100:
+        if width >= 3840:
             return 'uhd_4k'
 
         # 1080
-        if height > 720:
+        if width >= 1920:
             if interlaced:
                 return 'hd_1080i'
             else:
                 return 'hd_1080p'
 
         # 720
-        if height > 576:
+        if width >= 1280:
             return 'hd_720p'
 
         # 576
-        if height > 480:
+        if width >= 864:
             if interlaced:
                 return 'sd_576i'
             else:
@@ -104,8 +104,8 @@ class Base(PushHandler, CollectionHandler):
         if 'audio_channels' in p_media:
             data['audio_channels'] = cls.get_audio_channels(p_media['audio_channels'])
 
-        if 'height' in p_media and 'interlaced' in p_media:
-            data['resolution'] = cls.get_resolution(p_media['height'], p_media['interlaced'])
+        if 'width' in p_media and 'interlaced' in p_media:
+            data['resolution'] = cls.get_resolution(p_media['width'], p_media['interlaced'])
 
         # Remove any invalid/missing attributes
         for key in data.keys():

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/modes/push/movies.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/modes/push/movies.py
@@ -58,7 +58,7 @@ class Movies(Base):
 
                 MediaItem.audio_channels,
                 MediaItem.audio_codec,
-                MediaItem.height,
+                MediaItem.width,
                 MediaItem.interlaced
             ],
             account=self.current.account.plex.key,

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/modes/push/shows.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/sync/modes/push/shows.py
@@ -72,7 +72,7 @@ class Shows(Base):
             ], [], [
                 MediaItem.audio_channels,
                 MediaItem.audio_codec,
-                MediaItem.height,
+                MediaItem.width,
                 MediaItem.interlaced,
 
                 Episode.added_at

--- a/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/base_tests.py
+++ b/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/base_tests.py
@@ -20,20 +20,20 @@ def test_audio_codec():
 
 
 def test_resolution():
-    assert Base.get_resolution(480, False) == 'sd_480p'
-    assert Base.get_resolution(480, True) == 'sd_480i'
+    assert Base.get_resolution(720, False) == 'sd_480p'
+    assert Base.get_resolution(720, True) == 'sd_480i'
 
-    assert Base.get_resolution(576, False) == 'sd_576p'
-    assert Base.get_resolution(576, True) == 'sd_576i'
+    assert Base.get_resolution(864, False) == 'sd_576p'
+    assert Base.get_resolution(864, True) == 'sd_576i'
 
-    assert Base.get_resolution(720, False) == 'hd_720p'
-    assert Base.get_resolution(720, True) == 'hd_720p'
+    assert Base.get_resolution(1280, False) == 'hd_720p'
+    assert Base.get_resolution(1280, True) == 'hd_720p'
 
-    assert Base.get_resolution(1080, False) == 'hd_1080p'
-    assert Base.get_resolution(1080, True) == 'hd_1080i'
+    assert Base.get_resolution(1920, False) == 'hd_1080p'
+    assert Base.get_resolution(1920, True) == 'hd_1080i'
 
-    assert Base.get_resolution(2160, False) == 'uhd_4k'
-    assert Base.get_resolution(2160, True) == 'uhd_4k'
+    assert Base.get_resolution(3840, False) == 'uhd_4k'
+    assert Base.get_resolution(3840, True) == 'uhd_4k'
 
 
 def test_metadata_missing():

--- a/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/episode_tests.py
+++ b/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/episode_tests.py
@@ -96,7 +96,7 @@ def test_added_metadata():
                 'audio_codec': 'mp3',
                 'audio_channels': 2.0,
 
-                'height': 1080,
+                'width': 1920,
                 'interlaced': False
             }
         },
@@ -141,7 +141,7 @@ def test_added_metadata():
                 'audio_codec': 'ac3',
                 'audio_channels': 6.0,
 
-                'height': 576,
+                'width': 720,
                 'interlaced': True
             }
         },
@@ -164,7 +164,7 @@ def test_added_metadata():
 
                             'audio': 'dolby_digital',
                             'audio_channels': '5.1',
-                            'resolution': 'sd_576i'
+                            'resolution': 'sd_480i'
                         }
                     }
                 }

--- a/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/movie_tests.py
+++ b/Trakttv.bundle/Contents/Tests/tests/sync/handlers/collection/push/movie_tests.py
@@ -58,7 +58,7 @@ def test_added_metadata():
                 'audio_codec': 'mp3',
                 'audio_channels': 2.0,
 
-                'height': 1080,
+                'width': 1920,
                 'interlaced': False
             }
         },
@@ -87,7 +87,7 @@ def test_added_metadata():
                 'audio_codec': 'ac3',
                 'audio_channels': 6.0,
 
-                'height': 576,
+                'width': 720,
                 'interlaced': True
             }
         },
@@ -100,7 +100,7 @@ def test_added_metadata():
 
             'audio': 'dolby_digital',
             'audio_channels': '5.1',
-            'resolution': 'sd_576i'
+            'resolution': 'sd_480i'
         }
     )
 


### PR DESCRIPTION
Items that are letterboxed usually have the black bars removed from the video file, which reduces the vertical height of the video. Detecting the metadata resolution wasn't working correctly because of this. Instead, I switched to using the video width which remains constant even when an item has the black bars removed.

I tested this locally with my own library and it syncs up the correct resolution to Trakt now.