### PR TITLE
use external IDs from new agent if available (only for scrobbling)

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,4 +1,8 @@
 # Trakt.tv (for Plex)
+Now compatible with the Native Plex Movie Agent (should also be compatible with the upcoming Native Plex TV Agent). If you use the new agents, you require at least PMS version 1.20.1.3213 or higher, and you have to do a metadata refresh on the entire library after upgrading to this version. This plugin should be fully backwards compatible with the earlier supported agents.
+
+I cannot support other issues with the plugin outside of the new agent support.
+
 [![](https://img.shields.io/badge/license-GPLv3-blue.svg?style=flat-square)][license] [![](https://img.shields.io/requires/github/fuzeman/Plex-Trakt-Scrobbler.svg?style=flat-square)][requires.io] [![](https://img.shields.io/scrutinizer/build/g/fuzeman/Plex-Trakt-Scrobbler.svg?style=flat-square)][scrutinizer] [![](https://img.shields.io/scrutinizer/g/fuzeman/Plex-Trakt-Scrobbler.svg?style=flat-square)][scrutinizer] [![](https://img.shields.io/scrutinizer/coverage/g/fuzeman/Plex-Trakt-Scrobbler.svg?style=flat-square)][scrutinizer]  
 [![](https://img.shields.io/gitter/room/trakt/Plex-Trakt-Scrobbler.svg?style=social)][gitter.im]
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/extra/guid.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/extra/guid.py
@@ -1,0 +1,9 @@
+from plex.objects.core.base import Descriptor, Property
+
+
+class Guid(Descriptor):
+    id = Property(type=str)
+
+    @classmethod
+    def from_node(cls, client, node):
+        return cls.construct(client, cls.helpers.find(node, 'Guid'), child=True)

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/episode.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/episode.py
@@ -1,4 +1,5 @@
 from plex.objects.core.base import Property
+from plex.objects.library.extra.guid import Guid
 from plex.objects.library.metadata.season import Season
 from plex.objects.library.metadata.show import Show
 from plex.objects.library.metadata.base import Metadata
@@ -11,6 +12,15 @@ from plex.objects.mixins.scrobble import ScrobbleMixin
 class Episode(Video, Metadata, PlaylistItemMixin, RateMixin, ScrobbleMixin):
     show = Property(resolver=lambda: Episode.construct_show)
     season = Property(resolver=lambda: Episode.construct_season)
+    guids = Property(resolver=lambda: Guid.from_node)
+    agent_guid = Property('guid')
+    
+    @property
+    def guid(self):
+        try:
+            return self.guids.id
+        except:
+            return self.agent_guid
 
     index = Property(type=int)
     absolute_index = Property('absoluteIndex', int)

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/movie.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/movie.py
@@ -2,6 +2,7 @@ from plex.objects.core.base import Property
 from plex.objects.library.extra.country import Country
 from plex.objects.library.extra.genre import Genre
 from plex.objects.library.extra.role import Role
+from plex.objects.library.extra.guid import Guid
 from plex.objects.library.metadata.base import Metadata
 from plex.objects.library.video import Video
 from plex.objects.mixins.playlist_item import PlaylistItemMixin
@@ -13,6 +14,15 @@ class Movie(Video, Metadata, PlaylistItemMixin, RateMixin, ScrobbleMixin):
     country = Property(resolver=lambda: Country.from_node)
     genres = Property(resolver=lambda: Genre.from_node)
     roles = Property(resolver=lambda: Role.from_node)
+    guids = Property(resolver=lambda: Guid.from_node)
+    agent_guid = Property('guid')
+    
+    @property
+    def guid(self):
+        try:
+            return self.guids.id
+        except:
+            return self.agent_guid
 
     def __repr__(self):
         return '<Movie %r (%s)>' % (self.title, self.year)

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/season.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/season.py
@@ -1,4 +1,5 @@
 from plex.objects.core.base import Property
+from plex.objects.library.extra.guid import Guid
 from plex.objects.library.container import ChildrenContainer
 from plex.objects.library.metadata.show import Show
 from plex.objects.library.metadata.base import Metadata
@@ -10,6 +11,16 @@ class Season(Directory, Metadata, RateMixin):
     show = Property(resolver=lambda: Season.construct_show)
 
     index = Property(type=int)
+
+    guids = Property(resolver=lambda: Guid.from_node)
+    agent_guid = Property('guid')
+    
+    @property
+    def guid(self):
+        try:
+            return self.guids.id
+        except:
+            return self.agent_guid
 
     banner = Property
     theme = Property

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/show.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/show.py
@@ -1,4 +1,5 @@
 from plex.objects.core.base import Property
+from plex.objects.library.extra.guid import Guid
 from plex.objects.directory import Directory
 from plex.objects.library.container import LeavesContainer, ChildrenContainer
 from plex.objects.library.metadata.base import Metadata
@@ -8,6 +9,15 @@ from plex.objects.mixins.rate import RateMixin
 class Show(Directory, Metadata, RateMixin):
     index = Property(type=int)
     duration = Property(type=int)
+    guids = Property(resolver=lambda: Guid.from_node)
+    agent_guid = Property('guid')
+    
+    @property
+    def guid(self):
+        try:
+            return self.guids.id
+        except:
+            return self.agent_guid
 
     banner = Property
     theme = Property

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/__init__.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/__init__.py
@@ -5,6 +5,8 @@ from plex_database.models.media_item import MediaItem
 from plex_database.models.media_part import MediaPart
 from plex_database.models.metadata_item import MetadataItem, MetadataItemType
 from plex_database.models.metadata_item_settings import MetadataItemSettings
+from plex_database.models.tags import Tags
+from plex_database.models.taggings import Taggings
 
 # Model aliases
 Season = MetadataItem.alias()

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
@@ -5,7 +5,7 @@ from plex_database.models import MetadataItem
 from plex_database.models import Tags
 
 
-class SectionLocation(Model):
+class Taggings(Model):
     class Meta:
         database = db
         db_table = 'taggings'

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
@@ -1,0 +1,26 @@
+from plex_database.core import db
+
+from peewee import *
+from plex_database.models import MetadataItem
+from plex_database.models import Tags
+
+
+class SectionLocation(Model):
+    class Meta:
+        database = db
+        db_table = 'taggings'
+
+    metadata_item = ForeignKeyField(MetadataItem, null=True, related_name='taggings')
+    tag = ForeignKeyField(Tags, null=True, related_name='taggings')
+
+    index = IntegerField(null=True)
+    text = CharField(null=True)
+
+    time_offset = IntegerField(null=True)
+    end_time_offset = IntegerField(null=True)
+
+    thumb_url = CharField(null=True)
+
+    created_at = DateTimeField(null=True)
+    extra_data = CharField(null=True)
+

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
@@ -13,14 +13,3 @@ class Taggings(Model):
     metadata_item = ForeignKeyField(MetadataItem, null=True, related_name='taggings')
     tag = ForeignKeyField(Tags, null=True, related_name='taggings')
 
-    index = IntegerField(null=True)
-    text = CharField(null=True)
-
-    time_offset = BigIntegerField(null=True)
-    end_time_offset = BigIntegerField(null=True)
-
-    thumb_url = CharField(null=True)
-
-    created_at = DateTimeField(null=True)
-    extra_data = CharField(null=True)
-

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/taggings.py
@@ -16,8 +16,8 @@ class SectionLocation(Model):
     index = IntegerField(null=True)
     text = CharField(null=True)
 
-    time_offset = IntegerField(null=True)
-    end_time_offset = IntegerField(null=True)
+    time_offset = BigIntegerField(null=True)
+    end_time_offset = BigIntegerField(null=True)
 
     thumb_url = CharField(null=True)
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
@@ -1,0 +1,30 @@
+from plex_database.core import db
+
+from peewee import *
+
+
+class SectionLocation(Model):
+    class Meta:
+        database = db
+        db_table = 'tags'
+
+    parent = ForeignKeyField('self', null=True, related_name='children')
+
+    tag = CharField(null=True)
+    tag_type = IntegerField(null=True)
+
+    user_thumb_url = CharField(null=True)
+    user_art_url = CharField(null=True)
+    user_music_url = CharField(null=True)
+
+    created_at = DateTimeField(null=True)
+    updated_at = DateTimeField(null=True)
+
+    tag_value = CharField(null=True)
+    extra_data = CharField(null=True)
+
+    key = CharField(null=True)
+
+    @property
+    def parent_id(self):
+        return self._data['parent']

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
@@ -8,23 +8,6 @@ class Tags(Model):
         database = db
         db_table = 'tags'
 
-    parent = ForeignKeyField('self', null=True, related_name='children')
-
     tag = CharField(null=True)
     tag_type = IntegerField(null=True)
 
-    user_thumb_url = CharField(null=True)
-    user_art_url = CharField(null=True)
-    user_music_url = CharField(null=True)
-
-    created_at = DateTimeField(null=True)
-    updated_at = DateTimeField(null=True)
-
-    tag_value = CharField(null=True)
-    extra_data = CharField(null=True)
-
-    key = CharField(null=True)
-
-    @property
-    def parent_id(self):
-        return self._data['parent']

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_database/models/tags.py
@@ -3,7 +3,7 @@ from plex_database.core import db
 from peewee import *
 
 
-class SectionLocation(Model):
+class Tags(Model):
     class Meta:
         database = db
         db_table = 'tags'

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex_metadata/agents/entries.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex_metadata/agents/entries.py
@@ -171,6 +171,27 @@ AGENTS = {
     },
 
     #
+    # Native Agents
+    #
+
+    'imdb': {
+        'media': ['movie', 'show', 'season', 'episode'],
+        'service': 'imdb'
+    },
+
+    'tmdb': {
+        'media': ['movie', 'show', 'season', 'episode'],
+        'service': 'tmdb',
+        'type': int
+    },
+
+    'tvdb': {
+        'media': ['show', 'season', 'episode'],
+        'service': 'tvdb',
+        'type': int
+    },
+
+    #
     # Misc
     #
 


### PR DESCRIPTION
For issue #567 

Major props to SwiftPanda (Tautulli dev) for guiding me through the changes

I pulled in external GUIDs from the XML as an extra. I only pull in the first guid for now. There are some data issues with a handful of movies, but for the vast majority, this should be good enough. I added these for TV shows/seasons/episodes as well just as preparation for the new native Plex TV Agent. I then override the metadata.guid with this value so the rest of the scrobbling code remains unchanged. I also added these as agents in the agent.entries list. This code works for both old and new movies as I default to the agent.guid if it is not found in the external ID section.

I tested this code, and it works for scrobbles. It does *NOT* work for syncs. That requires modifications to the plex_database.library.py file, and while I tried to use the XML changes there, it resulted in long sync times and locked DBs as well as a variety of errors in Plex Media Server. I might need some help in modifying it to pull the external IDs from the tags. Below is the SQL code to find mappings between the guid and the external IDs which are stored as tags in the DB

```SQL
SELECT metadata_items.title,metadata_items.guid, metadata_items.year, tags.tag
FROM metadata_items
INNER JOIN taggings ON metadata_items.id=taggings.metadata_item_id
INNER JOIN tags ON taggings.tag_id=tags.id
where tags.tag_type = 314
```