### PR TITLE
Resolve scrobbling issues with new Plex Scanner/Agent

### DIFF
--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/extra/guid.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/extra/guid.py
@@ -6,4 +6,11 @@ class Guid(Descriptor):
 
     @classmethod
     def from_node(cls, client, node):
-        return cls.construct(client, cls.helpers.find(node, 'Guid'), child=True)
+        items = []
+        
+        for guid in cls.helpers.findall(node, 'Guid'):
+            _, obj = Guid.construct(client, guid, child=True)
+            
+            items.append(obj)
+        
+        return [], items

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/episode.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/episode.py
@@ -18,7 +18,7 @@ class Episode(Video, Metadata, PlaylistItemMixin, RateMixin, ScrobbleMixin):
     @property
     def guid(self):
         try:
-            return self.guids.id
+            return self.guids[0].id
         except:
             return self.agent_guid
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/movie.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/movie.py
@@ -20,7 +20,7 @@ class Movie(Video, Metadata, PlaylistItemMixin, RateMixin, ScrobbleMixin):
     @property
     def guid(self):
         try:
-            return self.guids.id
+            return self.guids[0].id
         except:
             return self.agent_guid
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/season.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/season.py
@@ -18,7 +18,7 @@ class Season(Directory, Metadata, RateMixin):
     @property
     def guid(self):
         try:
-            return self.guids.id
+            return self.guids[0].id
         except:
             return self.agent_guid
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/show.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plex/objects/library/metadata/show.py
@@ -15,7 +15,7 @@ class Show(Directory, Metadata, RateMixin):
     @property
     def guid(self):
         try:
-            return self.guids.id
+            return self.guids[0].id
         except:
             return self.agent_guid
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/core/identifier.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/core/identifier.py
@@ -9,19 +9,20 @@ log = logging.getLogger(__name__)
 
 class Identifier(object):
     @classmethod
-    def get_ids(cls, guid, strict=True):
+    def get_ids(cls, guids, strict=True):
         ids = {}
 
-        if not guid:
+        if not guids:
             return ids
 
-        if type(guid) is str:
-            # Parse raw guid
-            guid = Guid.parse(guid, strict=strict)
+        for guid in guids:
+            if type(guid.id) is str:
+                # Parse raw guid
+                guid = Guid.parse(guid.id, strict=strict)
 
-        if guid and guid.valid and guid.service in GUID_SERVICES:
-            ids[guid.service] = guid.id
-        elif strict:
-            return None
+            if guid and guid.valid and guid.service in GUID_SERVICES:
+                ids[guid.service] = guid.id
+            elif strict:
+                return None
 
         return ids

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
@@ -129,8 +129,7 @@ class Base(object):
                 'title': episode.title,
 
                 'season': season_num,
-                'number': episode_num,
-                'ids': ids
+                'number': episode_num
             }
         }
 

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
@@ -81,7 +81,7 @@ class Base(object):
     @classmethod
     def build_episode(cls, episode, guid, part):
         # Retrieve show identifier
-        ids = Identifier.get_ids(guid, strict=False)
+        ids = Identifier.get_ids(episode.guids, strict=False)
 
         if not ids:
             # Try map episode to a supported service (with OEM)
@@ -97,7 +97,15 @@ class Base(object):
 
         # Retrieve episode number
         season_num, episodes = ModuleManager['matcher'].process(episode)
-
+        
+        # If matching only a single episode, scrobble it with just id's
+        if len(episodes) == 1:
+            return {
+                'episode': {
+                    'ids': ids
+                }
+            }
+        
         if len(episodes) > 0 and part - 1 < len(episodes):
             episode_num = episodes[part - 1]
         elif len(episodes) > 0:
@@ -116,20 +124,19 @@ class Base(object):
             'show': {
                 'title': episode.show.title,
                 'year': episode.year,
-
-                'ids': ids
             },
             'episode': {
                 'title': episode.title,
 
                 'season': season_num,
-                'number': episode_num
+                'number': episode_num,
+                'ids': ids
             }
         }
 
     @staticmethod
     def build_movie(movie, guid, part):
-        ids = Identifier.get_ids(guid, strict=False)
+        ids = Identifier.get_ids(movie.guids, strict=False)
 
         if not ids:
             # Try map episode to a supported service (with OEM)

--- a/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
+++ b/Trakttv.bundle/Contents/Libraries/Shared/plugin/scrobbler/methods/core/base.py
@@ -97,15 +97,7 @@ class Base(object):
 
         # Retrieve episode number
         season_num, episodes = ModuleManager['matcher'].process(episode)
-        
-        # If matching only a single episode, scrobble it with just id's
-        if len(episodes) == 1:
-            return {
-                'episode': {
-                    'ids': ids
-                }
-            }
-        
+
         if len(episodes) > 0 and part - 1 < len(episodes):
             episode_num = episodes[part - 1]
         elif len(episodes) > 0:
@@ -115,16 +107,22 @@ class Base(object):
             log.warn('Matcher didn\'t return a valid result - season_num: %r, episodes: %r', season_num, episodes)
             episode_num = episode.index
 
-        # Process guid episode identifier overrides
-        if guid.season is not None:
-            season_num = guid.season
+        # Get the show metadata
+        if episode.show:
+            show_metadata = Metadata.get(episode.show.rating_key)
+            show_ids = Identifier.get_ids(show_metadata.guids, strict=False)
+        
+        if show_metadata:
+            show = {
+                'title': show_metadata.title,
+                'year': show_metadata.year,
+                
+                'ids': show_ids
+            }
 
         # Build request
         return {
-            'show': {
-                'title': episode.show.title,
-                'year': episode.year,
-            },
+            'show': show,
             'episode': {
                 'title': episode.title,
 


### PR DESCRIPTION
This should resolve new issues with scrobbling with the new Plex Scanner/Agent metadata.

Scrobbling should now correctly send the Show external `ids` to Trakt to ensure scrobble matches are more accurate.
This should also resolve some scenarios where multi-part episodes were not scrobbling correctly.

Scrobbling data sent to Trakt should now look like more akin to this:
```json
{
    "app_date": None,
    "progress": 14.24,
    "app_version": "1.3.3",
    "show": {
        "title": "Hawkeye (2021)",
        "ids": {
            "imdb": "tt10160804",
            "tmdb": 88329,
            "tvdb": 367146
        },
        "year": 2021
    },
    "episode": {
        "season": 1,
        "number": 1,
        "title": "Never Meet Your Heroes"
    }
}
```

Fixes #596 
Fixes #598 
Fixes #605 